### PR TITLE
added umsa to list of public servers

### DIFF
--- a/sources/data/available_public_servers.csv
+++ b/sources/data/available_public_servers.csv
@@ -35,3 +35,4 @@ UseGalaxy.no	https://usegalaxy.no/
 UseGalaxy.org (Main)	https://usegalaxy.org
 UseGalaxy.org.au	https://usegalaxy.org.au
 Viral Variant Visualizer (VVV)	https://viralvariant.anses.fr/
+UMSA    https://galaxy-umsa.grid.cesnet.cz


### PR DESCRIPTION
this adds the UMSA Galaxy instance which is coupled to usegalaxy.cz to the list.

Due to different tools being available on the instances, it would be beneficial to also collect the usage statistics from this instance, as it is used by the local RI :)

Are there any further additions needed to also include this Galaxy instance in the monitoring? Is there any configuration needed from the side of the admins?