### PR TITLE
Genome Lab: add recommended versions to VGP assembly workflows

### DIFF
--- a/communities/genome/lab/assembly.yml
+++ b/communities/genome/lab/assembly.yml
@@ -260,13 +260,13 @@ tabs:
             - title_md: Kmer profiling
               description_md: >
                 This workflow produces a Meryl database and Genomescope outputs that will be used to determine parameters for following workflows, and assess the quality of genome assemblies. Specifically, it provides information about the genomic complexity, such as the genome size and levels of heterozygosity and repeat content, as well about the data quality.
+                <p><strong>Recommended: v0.1.7 (recently tested).</strong></p>
               inputs:
                 - datatypes:
                     - fastq
                   label: PacBio HiFi reads
               buttons:
                 - icon: run
-                <p><strong>Recommended: v0.1.7 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/kmer-profiling-hifi-VGP1/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view
@@ -280,6 +280,7 @@ tabs:
                 <p>
                   <small> Note: if you have multiple input files for each HiC set, they need to be concatenated. The forward set needs to be concatenated in the same order as reverse set. </small>
                 </p>
+                <p><strong>Recommended: v0.1.10 (recently tested).</strong></p>
               inputs:
                 - datatypes:
                     - fasta
@@ -298,7 +299,6 @@ tabs:
                   label: <code>GenomeScope</code> genome profile summary
               buttons:
                 - icon: run
-                <p><strong>Recommended: v0.1.10 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/Assembly-Hifi-HiC-phasing-VGP4/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view
@@ -308,6 +308,7 @@ tabs:
             - title_md: Hifi assembly without HiC data
               description_md: >
                 This workflow uses <code>hifiasm</code> to generate primary and alternate pseudohaplotype assemblies. This workflow includes three tools for evaluating assembly quality: <code>gfastats</code>, <code>BUSCO</code> and <code>Merqury</code>.
+                <p><strong>Recommended: v0.3.5 (recently tested).</strong></p>
               inputs:
                 - datatypes:
                     - fasta
@@ -320,7 +321,6 @@ tabs:
                   label: <code>GenomeScope</code> genome profile summary
               buttons:
                 - icon: run
-                <p><strong>Recommended: v0.3.5 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/Assembly-Hifi-only-VGP3/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view
@@ -330,6 +330,7 @@ tabs:
             - title_md: HiC scaffolding
               description_md: >
                 This workflow scaffolds the assembly contigs using information from HiC data.
+                <p><strong>Recommended: v1.8 (recently tested).</strong></p>
               inputs:
                 - datatypes:
                     - gfa
@@ -342,7 +343,6 @@ tabs:
                   label: HiC reverse reads
               buttons:
                 - icon: run
-                <p><strong>Recommended: v1.8 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/Scaffolding-HiC-VGP8/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view

--- a/communities/genome/lab/assembly.yml
+++ b/communities/genome/lab/assembly.yml
@@ -266,6 +266,7 @@ tabs:
                   label: PacBio HiFi reads
               buttons:
                 - icon: run
+                <p><strong>Recommended: v0.1.7 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/kmer-profiling-hifi-VGP1/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view
@@ -297,6 +298,7 @@ tabs:
                   label: <code>GenomeScope</code> genome profile summary
               buttons:
                 - icon: run
+                <p><strong>Recommended: v0.1.10 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/Assembly-Hifi-HiC-phasing-VGP4/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view
@@ -318,6 +320,7 @@ tabs:
                   label: <code>GenomeScope</code> genome profile summary
               buttons:
                 - icon: run
+                <p><strong>Recommended: v0.3.5 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/Assembly-Hifi-only-VGP3/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view
@@ -339,6 +342,7 @@ tabs:
                   label: HiC reverse reads
               buttons:
                 - icon: run
+                <p><strong>Recommended: v1.8 (recently tested).</strong></p>
                   link: "{{ galaxy_base_url }}/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow/github.com/iwc-workflows/Scaffolding-HiC-VGP8/main"
                   tip: Run this workflow in Galaxy {{ site_name }}
                 - icon: view


### PR DESCRIPTION
## Changes to `communities/genome/lab/assembly.yml`

Adds recommended version notes to 4 of the 5 VGP assembly workflows (Decontamination left without a note as it has only 1 version):

- Kmer profiling (VGP1): Recommended v0.1.7
- HiFi + HiC phasing (VGP4): Recommended v0.1.10
- HiFi only (VGP3): Recommended v0.3.5
- HiC scaffolding (VGP8): Recommended v1.8

All tested on Galaxy Australia (usegalaxy.org.au).