### PR TITLE
Fix "Take me back" link pointing to genome subdomain instead of main site

### DIFF
--- a/communities/genome/lab/usegalaxy.org.au/templates/intro.html
+++ b/communities/genome/lab/usegalaxy.org.au/templates/intro.html
@@ -26,7 +26,7 @@
             Switch between sites quickly using the dropdown in Galaxy {{ site_name }}'s main navigation bar:
             <img class="w-100 my-3 mx-auto" src="https://github.com/usegalaxy-au/galaxy-media-site/blob/dev/webapp/home/static/home/img/subdomains/site-switcher.png?raw=true" alt="Switch site button">
           </div>
-          <p><a class="ga-btn" href="{{ galaxy_base_url }}" target="_blank">Take me back to Galaxy {{ site_name }}</a></p>
+          <p><a class="ga-btn" href="https://{{ root_domain }}" target="_blank">Take me back to Galaxy {{ site_name }}</a></p>
           <p><a class="ga-btn" href="{{ support_url }}">Galaxy {{ site_name }} support</a></p>
         </div>
 


### PR DESCRIPTION
The link used {{ galaxy_base_url }} which resolves to genome.usegalaxy.org.au. Changed to https://{{ root_domain }} so it correctly links back to usegalaxy.org.au.