### PR TITLE
Fix recommended version for WFHub 220 BAM to FASTQ workflow

### DIFF
--- a/communities/genome/lab/assembly.yml
+++ b/communities/genome/lab/assembly.yml
@@ -105,7 +105,7 @@ tabs:
             - title_md: BAM to FASTQ + QC v1.0
               description_md: >
                 Convert a BAM file to FASTQ format to perform QC analysis (required if your data is in BAM format).
-                <p><strong>Recommended: Version 2 (recently tested).</strong></p>
+                <p><strong>Recommended: Version 1 (recently tested).</strong></p>
               inputs:
                 - datatypes:
                     - bam


### PR DESCRIPTION
The Genome Lab page said "Recommended: Version 2" but Version 2 does not exist on WorkflowHub — only Version 1 and a commit-based snapshot. Both are identical in content. Corrected to Version 1.