### PR TITLE
Update communities JSON in workflow file to use workflow4metabolomics

### DIFF
--- a/.github/workflows/filter_communities.yaml
+++ b/.github/workflows/filter_communities.yaml
@@ -27,7 +27,7 @@ jobs:
         id: prepare
         run: |
           # produce a JSON array string, e.g. from a file or script
-          echo '["assembly","biodiversity","earth","genome","imaging","machine-learning","metabolomics","microgalaxy","proteomics","spoc"]' > communities.json
+          echo '["assembly","biodiversity","earth","genome","imaging","machine-learning","workflow4metabolomics","microgalaxy","proteomics","spoc"]' > communities.json
           communities=$(cat communities.json)
           echo "communities=$communities" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Replaces the superseded `metabolomics` community with `workflow4metabolomics` in the CI action to perform the weekly updates.