### PR TITLE
Move "Request tools" to the end of the tools table

### DIFF
--- a/.github/workflows/filter_communities.yaml
+++ b/.github/workflows/filter_communities.yaml
@@ -27,7 +27,8 @@ jobs:
         id: prepare
         run: |
           # produce a JSON array string, e.g. from a file or script
-          echo '["assembly","biodiversity","earth","genome","imaging","machine-learning","workflow4metabolomics","microgalaxy","proteomics","spoc"]' > communities.json          communities=$(cat communities.json)
+          echo '["assembly","biodiversity","earth","genome","imaging","machine-learning","workflow4metabolomics","microgalaxy","proteomics","spoc"]' > communities.json
+          communities=$(cat communities.json)
           echo "communities=$communities" >> $GITHUB_OUTPUT
 
   community-filter:

--- a/.github/workflows/filter_communities.yaml
+++ b/.github/workflows/filter_communities.yaml
@@ -27,8 +27,7 @@ jobs:
         id: prepare
         run: |
           # produce a JSON array string, e.g. from a file or script
-          echo '["biodiversity"]' > communities.json
-          communities=$(cat communities.json)
+          echo '["assembly","biodiversity","earth","genome","imaging","machine-learning","workflow4metabolomics","microgalaxy","proteomics","spoc"]' > communities.json          communities=$(cat communities.json)
           echo "communities=$communities" >> $GITHUB_OUTPUT
 
   community-filter:

--- a/.github/workflows/filter_communities.yaml
+++ b/.github/workflows/filter_communities.yaml
@@ -27,7 +27,7 @@ jobs:
         id: prepare
         run: |
           # produce a JSON array string, e.g. from a file or script
-          echo '["assembly","biodiversity","earth","genome","imaging","machine-learning","workflow4metabolomics","microgalaxy","proteomics","spoc"]' > communities.json
+          echo '["biodiversity"]' > communities.json
           communities=$(cat communities.json)
           echo "communities=$communities" >> $GITHUB_OUTPUT
 

--- a/sources/bin/extract_galaxy_tools.py
+++ b/sources/bin/extract_galaxy_tools.py
@@ -1044,7 +1044,7 @@ def fill_lab_tool_section(
     # ensure the request_tools tab is at the bottom
     if request_tools_elem is not None:
         tabs.append(request_tools_elem)
-    
+
     new_lab_section = {
         "id": lab_section["id"],
         "title": lab_section["title"],

--- a/sources/bin/extract_galaxy_tools.py
+++ b/sources/bin/extract_galaxy_tools.py
@@ -988,8 +988,11 @@ def fill_lab_tool_section(
     Fill Lab tool section
     """
     tabs = []
-    for element in lab_section["tabs"]:
-        if element["id"] == "request_tools":
+    request_tools_elem = None
+    for element in lab_section.get("tabs", []):
+        if element.get("id") == "request_tools":
+            request_tools_elem = element
+        else:
             tabs.append(element)
 
     for grp_id, group in top_items_per_category.groupby("Category"):
@@ -1038,6 +1041,10 @@ def fill_lab_tool_section(
             }
         )
 
+    # ensure the request_tools tab is at the bottom
+    if request_tools_elem is not None:
+        tabs.append(request_tools_elem)
+    
     new_lab_section = {
         "id": lab_section["id"],
         "title": lab_section["title"],


### PR DESCRIPTION
based on feedback from the AU team, we moved the "request tools" section to the last section of the tools' table
https://github.com/galaxyproject/galaxy_codex/pull/588

However, the  script brings back this section to the top, this patch keeps the "request tools" section to the end of the table.

I tested it on the biodiversity genomics lab, it works.