### PR TITLE
Add seqtk_seq tool to Genome Lab data import tools

### DIFF
--- a/communities/genome/lab/data.yml
+++ b/communities/genome/lab/data.yml
@@ -99,6 +99,17 @@ tabs:
           - icon: run
             link: "{{ galaxy_base_url }}/tool_runner?tool_id=upload1"
             tip: Run this tool
+      - title_md: <code>seqtk_seq</code> - subsample sequences
+        description_md: >
+          Subsample large data sets down to a manageable size for testing tools and workflows. Set the "Sample fraction of sequences" parameter to control the output size.
+        inputs:
+          - datatypes:
+              - fastq
+              - fasta
+        buttons:
+          - icon: run
+            link: "{{ galaxy_base_url }}/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fiuc%2Fseqtk%2Fseqtk_seq"
+            tip: Run this tool
       - title_md: <code>FastQC</code> - sequence quality reports
         description_md: >
           Before using your sequencing data, it's important to ensure that


### PR DESCRIPTION
## Summary
- Adds a `seqtk_seq` tool card to the Tools tab of the Genome Lab data import/preparation page
- Surfaces the subsampling tool already referenced in the Overview tab's FAQ ("How can I subsample my data?") as a runnable card, alongside the other data-prep tools

## Test plan
- [ ] Preview rendered page and confirm the new card appears between "Import data to Galaxy" and "FastQC"
- [ ] Confirm the Run button launches `seqtk_seq` correctly