### PR TITLE
Issue : Lab files created for communities automatically

### DIFF
--- a/.github/workflows/fetch_filter_resources.yaml
+++ b/.github/workflows/fetch_filter_resources.yaml
@@ -137,14 +137,14 @@ jobs:
 #          path: communities/all/resources/citations.json
   merge-fetch:
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && needs.fetch-tools-stepwise.result == 'success' }}
+    if: ${{ !cancelled() && needs.fetch-tools-stepwise.result == 'success' && needs.fetch-tutorials.result == 'success' && needs.fetch-workflows.result == 'success' }}
     needs: 
       - fetch-servers
       - fetch-tools-stepwise
       - fetch-tutorials
       - fetch-workflows
 #      - fetch-citations
-    name: Merge tools
+    name: Merge tools & Push changes
     steps:
       - name: Checkout main
         uses: actions/checkout@v7

--- a/.github/workflows/filter_communities.yaml
+++ b/.github/workflows/filter_communities.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'scorrear_PR_too_big'
     paths:
       - 'communities/all/resources/tools.tsv'
 
@@ -26,9 +25,8 @@ jobs:
       - name: Prepare communities JSON
         id: prepare
         run: |
-          # produce a JSON array string, e.g. from a file or script
-          echo '["assembly","biodiversity","earth","genome","imaging","machine-learning","workflow4metabolomics","microgalaxy","proteomics","spoc"]' > communities.json
-          communities=$(cat communities.json)
+          # List all directories in communities/ and format as a JSON array
+          communities=$(ls -d communities/*/ | xargs -n1 basename | jq -R -s -c 'split("\n")[:-1]')
           echo "communities=$communities" >> $GITHUB_OUTPUT
 
   community-filter:
@@ -74,8 +72,13 @@ jobs:
       #  env: 
       #    COMMUNITY: ${{ matrix.community }}
       - name: Populate lab for communities
+        # Should only run for communities who did manual curation of their resources
         run: |
-          bash sources/bin/populate_labs.sh
+          if [ -e "communities/${{ matrix.community }}/resources/curated_tools.tsv" ]; then
+            bash sources/bin/populate_labs.sh
+          else
+            echo "No curation for this community"
+          fi
         env: 
           COMMUNITY: ${{ matrix.community }}
       - name: Create Pull Request

--- a/sources/bin/extract_galaxy_workflows.py
+++ b/sources/bin/extract_galaxy_workflows.py
@@ -279,8 +279,8 @@ class Workflows:
         for wf in server_wfs:
             if wf["published"] and wf["importable"] and not wf["deleted"] and not wf["hidden"]:
                 count += 1
-                # The following workflow (id=f65a2f2a19bea880) caused the request to crash, it was reported to the Galaxy team, in the meantime, we are skipping it
-                if wf["id"] == "f65a2f2a19bea880":
+                # The following workflows (id=f65a2f2a19bea880 & id=afec91accac0d99b) caused the request to crash, it was reported to the Galaxy team, in the meantime, we are skipping it
+                if wf["id"] in {"f65a2f2a19bea880", "afec91accac0d99b"}:
                     continue
                 server_wf = shared.get_request_json(
                     f"{server}/api/workflows/{wf['id']}",


### PR DESCRIPTION
Will solve issue https://github.com/galaxyproject/galaxy_codex/issues/737

Issue : 
Since our latest big update, lab files are created automatically for each community, even if they never did manual curation. Therefore, it creates empty, useless files

For example : https://github.com/galaxyproject/galaxy_codex/pull/674/changes#diff-f5f9d11e295ab0f3afa867e779a867e76f294670c2471202aa63806ab0355f0a

Solution : 
    - Update the GitHub action to only generate lab files if 'galaxy_codex/communities/<community>/resources/curated_tools.tsv exists
    - Also updated GitHub action to automatically pull the list of community and not rely on a manual entry of a list
    - Also updated the weekly resource update to only run the last step if the previous ones worked. 
    - Added a workflow ID to skip that was causing the weekly update to crash (https://github.com/galaxyproject/galaxy_codex/actions/runs/31303035447/job/93218796320)

Tests:
Tested on my repo and it worked : https://github.com/scorreard/galaxy_codex/pull/26/changes