### PR TITLE
Fix "Take me back" link in base Genome Lab intro template

### DIFF
--- a/communities/genome/lab/templates/intro.html
+++ b/communities/genome/lab/templates/intro.html
@@ -27,7 +27,7 @@
             <img class="w-100 my-3 mx-auto" src="https://github.com/galaxyproject/galaxy_codex/blob/main/communities/all/labs/assets/site-switcher.png?raw=true" alt="Switch site button">
           </div>
 
-          <p><a class="ga-btn" href="{{ galaxy_base_url }}" target="_blank">Take me back to Galaxy {{ site_name }}</a></p>
+          <p><a class="ga-btn" href="https://{{ root_domain }}" target="_blank">Take me back to Galaxy {{ site_name }}</a></p>
           <p><a class="ga-btn" href="{{ support_url }}">Galaxy {{ site_name }} support</a></p>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
The base Genome Lab intro template (`communities/genome/lab/templates/intro.html`) linked the "Take me back to Galaxy" button to `{{ galaxy_base_url }}`, which resolves to the genome subdomain (e.g. `genome.usegalaxy.org.au`). Clicking it kept users on the Genome Lab instead of returning them to the base site.

Changed to `https://{{ root_domain }}` so it correctly links back to the main site (e.g. `usegalaxy.org.au`). This fixes the link for every Genome Lab subdomain.

Note: this is the template actually rendered by the AU config, which inherits `intro_md` from `base.yml` and does not override it. A previous fix (#667) edited the `usegalaxy.org.au/`-specific intro override, which no config references, so it had no effect on the live page. That orphaned override file is left in place for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)