### PR TITLE
Reduce whitespace below Genome Lab intro tagline

### DIFF
--- a/communities/genome/lab/templates/intro.html
+++ b/communities/genome/lab/templates/intro.html
@@ -1,4 +1,4 @@
-<section class="my-5" id="tagline">
+<section class="mt-5 mb-3" id="tagline">
   <p>
     Welcome to the Galaxy {{ site_name }} {{ lab_name }}. Get quick access to tools, workflows and tutorials for genome assembly and annotation.
     <br>


### PR DESCRIPTION
The Genome Lab intro tagline `<section>` (`communities/genome/lab/templates/intro.html`) used Bootstrap `my-5` (3rem margin top and bottom), leaving a large gap between the welcome text and the first section ("Data import and preparation").

The intro is rendered by the labs engine inside a flexbox row (`<div class="row"><div class="col">…</div></div>`), so the tagline's bottom margin does not collapse with the first section below it — it adds as real space. Reducing it directly tightens the gap.

Changed `my-5` → `mt-5 mb-3`: keeps the 3rem space above, trims the space below to 1rem. The remaining gap is the first section's own top margin, which is consistent with the spacing between all the other sections. Vertical spacing only, no responsive impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)