### PR TITLE
Add fallback to GITHUB_TOKEN in checkout action

### DIFF
--- a/.github/workflows/fetch_filter_resources.yaml
+++ b/.github/workflows/fetch_filter_resources.yaml
@@ -148,9 +148,9 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v7
-        with:
+        # with:
           # We pass the "PAT" secret to the checkout action; if no PAT secret is available to the workflow runner (eg. Dependabot) we fall back to the default "GITHUB_TOKEN".
-          token: ${{ secrets.PAT || secrets.GH_ACTIONS_PAT || secrets.GITHUB_TOKEN }}
+          # token: ${{ secrets.PAT || secrets.GH_ACTIONS_PAT || secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'

--- a/.github/workflows/fetch_filter_resources.yaml
+++ b/.github/workflows/fetch_filter_resources.yaml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           # We pass the "PAT" secret to the checkout action; if no PAT secret is available to the workflow runner (eg. Dependabot) we fall back to the default "GITHUB_TOKEN".
-          token: ${{ secrets.PAT || secrets.GH_ACTIONS_PAT }}
+          token: ${{ secrets.PAT || secrets.GH_ACTIONS_PAT || secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'


### PR DESCRIPTION
The weekly update is failing since August 6

```
/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +0f8f4a3c533fcd24b6afd7c125d83d16a83ca728:refs/remotes/origin/main
  Error: fatal: could not read Username for 'https://github.com/': terminal prompts disabled
  The process '/usr/bin/git' failed with exit code 128
```

This fix was tested and works